### PR TITLE
Add if/split impls to parser with tests

### DIFF
--- a/spl-lib/src/llspl/parser.rs
+++ b/spl-lib/src/llspl/parser.rs
@@ -7,6 +7,8 @@
 //! atom ::= pure
 //!        | project
 //!        | download
+//!        | split
+//!        | if
 //!        | parens
 //!
 //! parens ::= "(" seq ")"
@@ -16,12 +18,14 @@
 //! project ::= "project" transformer // Defined in json_transformers::parse
 //!
 //! download ::= "download" url
+//! 
+//! split ::= "split" parens
+//! 
+//! if ::= "if" parens "{" seq "}" "else" "{" seq "}"
 
 /* TODO(arjun):
 
     Fetch(String),
-    Split(Box<Expr>),
-    If(Box<Expr>, Box<Expr>, Box<Expr>)
 */
 
 extern crate nom;

--- a/spl-lib/src/llspl/syntax.rs
+++ b/spl-lib/src/llspl/syntax.rs
@@ -23,6 +23,15 @@ pub enum Payload {
     Json(serde_json::Value)
 }
 
+impl Clone for Payload {
+    fn clone(&self) -> Self {
+        match self {
+            Payload::Chunk(c) => Payload::Chunk(hyper::Chunk::from(c.to_vec())),
+            Payload::Json(v) => Payload::Json(v.clone())
+        }
+    }
+}
+
 impl PartialEq for Payload {
   fn eq(&self, other: &Payload) -> bool {
       match (self, other) {


### PR DESCRIPTION
- `pure` exprs now take string args within `"..."`
- `split` exprs parse as `split (<expr>)`
- `if` exprs parse as `if (<expr>) { <expr> } else { <expr> }`.
- Added some tests for the parsing/evaluation of these exprs.